### PR TITLE
Remove reaper

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/apex/log"
 	"github.com/deviceplane/deviceplane/pkg/agent"
@@ -36,9 +34,6 @@ func init() {
 }
 
 func main() {
-	// Start zombie reaper
-	go reaper()
-
 	conf.Load(&config)
 
 	lvl, err := log.ParseLevel(config.LogLevel)
@@ -69,22 +64,4 @@ func main() {
 	}
 
 	agent.Run()
-}
-
-// reaper reaps zombie processes
-// This is needed because SSH spawns child processes that can die
-// https://en.wikipedia.org/wiki/Zombie_process
-func reaper() {
-	c := make(chan os.Signal, 2048)
-	signal.Notify(c, syscall.SIGCHLD)
-
-	for range c {
-		for {
-			if pid, err := syscall.Wait4(
-				-1, nil, syscall.WNOHANG, nil,
-			); err != nil || pid <= 0 {
-				break
-			}
-		}
-	}
 }


### PR DESCRIPTION
This is no longer required now that our agent is running on the host rather than in a container.