### PR TITLE
Make scheduling rules not schedule by default, if no scheduling rule is set

### DIFF
--- a/pkg/controller/query/query.go
+++ b/pkg/controller/query/query.go
@@ -52,7 +52,7 @@ func DeviceMatchesQuery(device models.Device, query models.Query) (bool, error) 
 			return false, nil
 		}
 	}
-	return true, nil
+	return false, nil
 }
 
 func deviceMatchesFilter(device models.Device, filter models.Filter) (bool, error) {


### PR DESCRIPTION
Controversial change but I think it's important once you start running multiple projects. Definitely unexpected behavior for me to see applications scheduled without a scheduling rule set.