### PR TITLE
Env vars, enable/disable sign up and fix null field

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -29,43 +29,55 @@ var (
 	addr = kingpin.
 		Flag("addr", "").
 		Default(":8080").
+		OverrideDefaultFromEnvar("ADDR").
 		String()
 	mysql = kingpin.
 		Flag("mysql", "").
 		Default("deviceplane:deviceplane@tcp(localhost:3306)/deviceplane?parseTime=true").
+		OverrideDefaultFromEnvar("MYSQL_CONNECTION_STRING").
 		String()
 	statsdAddress = kingpin.
 			Flag("statsd", "").
 			Default("127.0.0.1:8125").
+			OverrideDefaultFromEnvar("STATS_ADDRESS").
 			String()
 	allowedOrigins = kingpin.
 			Flag("allowed-origin", "").
+			OverrideDefaultFromEnvar("ALLOWED_ORIGINS").
 			Strings()
 	emailProvider = kingpin.
 			Flag("email-provider", "").
 			Default("none").
+			OverrideDefaultFromEnvar("EMAIL_PROVIDER").
 			String()
 	emailFromName = kingpin.
 			Flag("email-from-name", "").
 			Default("Deviceplane").
+			OverrideDefaultFromEnvar("EMAIL_FROM_NAME").
 			String()
 	emailFromAddress = kingpin.
 				Flag("email-from-address", "").
+				OverrideDefaultFromEnvar("EMAIL_FROM_ADDRESS").
 				String()
 	allowedEmailDomains = kingpin.
 				Flag("allowed-email-domain", "").
+				OverrideDefaultFromEnvar("ALLOWED_EMAIL_DOMAINS").
 				Strings()
 	smtpServer = kingpin.
 			Flag("smtp-server", "").
+			OverrideDefaultFromEnvar("SMTP_SERVER").
 			String()
 	smtpPort = kingpin.
 			Flag("smtp-port", "").
+			OverrideDefaultFromEnvar("SMTP_PORT").
 			Int()
 	smtpUsername = kingpin.
 			Flag("smtp-username", "").
+			OverrideDefaultFromEnvar("SMTP_USERNAME").
 			String()
 	smtpPassword = kingpin.
 			Flag("smtp-password", "").
+			OverrideDefaultFromEnvar("SMTP_PASSWORD").
 			String()
 )
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -25,6 +25,7 @@ import (
 var version = "dev"
 var name = "deviceplane-controller"
 
+//commit for test
 var (
 	addr = kingpin.
 		Flag("addr", "").

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -36,6 +36,10 @@ var (
 		Default("deviceplane:deviceplane@tcp(localhost:3306)/deviceplane?parseTime=true").
 		OverrideDefaultFromEnvar("MYSQL_CONNECTION_STRING").
 		String()
+	enableSignUp = kingpin.
+			Flag("enableSignUp", "").
+			OverrideDefaultFromEnvar("ENABLE_SING_UP").
+			Bool()
 	statsdAddress = kingpin.
 			Flag("statsd", "").
 			Default("127.0.0.1:8125").
@@ -122,7 +126,7 @@ func main() {
 	runnerManager.Start()
 
 	svc := service.NewService(sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore,
-		sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore,
+		sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, sqlStore, *enableSignUp,
 		emailProvider, *emailFromName, *emailFromAddress, *allowedEmailDomains, statikFS, st, connman, allowedOriginURLs)
 
 	server := &http.Server{

--- a/pkg/controller/service/service.go
+++ b/pkg/controller/service/service.go
@@ -44,6 +44,7 @@ var (
 	errTokenExpired          = errors.New("token expired")
 )
 
+//Service struct
 type Service struct {
 	users                      store.Users
 	passwordRecoveryTokens     store.PasswordRecoveryTokens
@@ -82,6 +83,7 @@ type Service struct {
 	upgrader websocket.Upgrader
 }
 
+//NewService function
 func NewService(
 	users store.Users,
 	registrationTokens store.RegistrationTokens,
@@ -1233,7 +1235,7 @@ func (s *Service) updateProject(w http.ResponseWriter, r *http.Request,
 ) {
 	var updateProjectRequest struct {
 		Name          string `json:"name" validate:"name"`
-		DatadogApiKey string `json:"datadogApiKey"`
+		DatadogAPIKey string `json:"datadogApiKey"`
 	}
 	if err := read(r, &updateProjectRequest); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -1250,7 +1252,7 @@ func (s *Service) updateProject(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	project, err := s.projects.UpdateProject(r.Context(), projectID, updateProjectRequest.Name, updateProjectRequest.DatadogApiKey)
+	project, err := s.projects.UpdateProject(r.Context(), projectID, updateProjectRequest.Name, updateProjectRequest.DatadogAPIKey)
 	if err != nil {
 		log.WithError(err).Error("update project")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -2890,8 +2892,8 @@ func (s *Service) getBundle(w http.ResponseWriter, r *http.Request, project mode
 	}
 
 	bundle := models.Bundle{
-		DesiredAgentSpec:    device.DesiredAgentSpec,
-		DesiredAgentVersion: device.DesiredAgentVersion,
+		DesiredAgentSpec:    device.DesiredAgentSpec.String,
+		DesiredAgentVersion: device.DesiredAgentVersion.String,
 	}
 
 	for _, application := range applications {

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"database/sql"
 	"time"
 )
 
@@ -117,8 +118,8 @@ type Device struct {
 	ProjectID           string            `json:"projectId" yaml:"projectId"`
 	Name                string            `json:"name" yaml:"name"`
 	RegistrationTokenID *string           `json:"registrationTokenId" yaml:"registrationTokenId"`
-	DesiredAgentSpec    string            `json:"desiredAgentSpec" yaml:"desiredAgentSpec"`
-	DesiredAgentVersion string            `json:"desiredAgentVersion" yaml:"desiredAgentVersion"`
+	DesiredAgentSpec    sql.NullString    `json:"desiredAgentSpec" yaml:"desiredAgentSpec"`
+	DesiredAgentVersion sql.NullString    `json:"desiredAgentVersion" yaml:"desiredAgentVersion"`
 	Info                DeviceInfo        `json:"info" yaml:"info"`
 	LastSeenAt          time.Time         `json:"lastSeenAt" yaml:"lastSeenAt"`
 	Status              DeviceStatus      `json:"status" yaml:"status"`


### PR DESCRIPTION
Added env var options to flags. This is useful specially to deploy docker images.

Added feature: enable sign up. This is a flag to enable and disable sign up. Could be useful to set in a public implementation where it admins doesn't want more registed users. It is more a "security" feature.

Fixed: When agent is deployed in a non supported OS version, the fields DesiredAgentSpec and DesiredAgentVersion are filled with NULL in database. Then when users want to list all devices, the application crashes, because it's trying to convert NULL to string (error=sql: Scan error on column index 5, name "desired_agent_spec": converting NULL to string is unsupported). I changed the types of this two fields from string to sql.NullString to support this situation and it works.