### PR TITLE
Whitelist metric tags

### DIFF
--- a/pkg/controller/store/mysql/store.go
+++ b/pkg/controller/store/mysql/store.go
@@ -20,21 +20,20 @@ type scanner interface {
 }
 
 const (
-	userPrefix                      = "usr"
-	registrationTokenPrefix         = "reg"
-	passwordRecoveryTokenPrefix     = "pwr"
-	sessionPrefix                   = "ses"
-	userAccessKeyPrefix             = "uky"
-	projectPrefix                   = "prj"
-	rolePrefix                      = "rol"
-	serviceAccountPrefix            = "sac"
-	serviceAccountAccessKeyPrefix   = "sak"
-	devicePrefix                    = "dev"
-	deviceRegistrationTokenPrefix   = "drt"
-	deviceAccessKeyPrefix           = "dak"
-	applicationPrefix               = "app"
-	releasePrefix                   = "rel"
-	ExposedMetricConfigHolderPrefix = "mtc"
+	userPrefix                    = "usr"
+	registrationTokenPrefix       = "reg"
+	passwordRecoveryTokenPrefix   = "pwr"
+	sessionPrefix                 = "ses"
+	userAccessKeyPrefix           = "uky"
+	projectPrefix                 = "prj"
+	rolePrefix                    = "rol"
+	serviceAccountPrefix          = "sac"
+	serviceAccountAccessKeyPrefix = "sak"
+	devicePrefix                  = "dev"
+	deviceRegistrationTokenPrefix = "drt"
+	deviceAccessKeyPrefix         = "dak"
+	applicationPrefix             = "app"
+	releasePrefix                 = "rel"
 )
 
 func newUserID() string {
@@ -91,10 +90,6 @@ func newApplicationID() string {
 
 func newReleaseID() string {
 	return fmt.Sprintf("%s_%s", releasePrefix, ksuid.New().String())
-}
-
-func newExposedMetricConfigHolderID() string {
-	return fmt.Sprintf("%s_%s", ExposedMetricConfigHolderPrefix, ksuid.New().String())
 }
 
 var (

--- a/pkg/metrics/datadog/processing/postprocessing.go
+++ b/pkg/metrics/datadog/processing/postprocessing.go
@@ -81,6 +81,26 @@ func metricProcessorFunc(
 				)
 			}
 
+			// Only keep tags on whitelist
+			if len(exposedMetric.WhitelistedTags) != 0 { // Trim only if whitelist exists
+				var allowedTags []string
+				for _, tagPair := range m.Tags {
+					tag := strings.Split(tagPair, ":")[0]
+
+					if strings.HasPrefix(tag, "deviceplane.") {
+						allowedTags = append(allowedTags, tagPair)
+						continue
+					}
+					for _, wTagName := range exposedMetric.WhitelistedTags {
+						if tag == wTagName {
+							allowedTags = append(allowedTags, tagPair)
+							break
+						}
+					}
+				}
+				m.Tags = allowedTags
+			}
+
 			// Optional labels
 			if device != nil {
 				for _, label := range exposedMetric.Labels {

--- a/pkg/metrics/datadog/processing/postprocessing.go
+++ b/pkg/metrics/datadog/processing/postprocessing.go
@@ -91,10 +91,17 @@ func metricProcessorFunc(
 						allowedTags = append(allowedTags, tagPair)
 						continue
 					}
-					for _, wTagName := range exposedMetric.WhitelistedTags {
-						if tag == wTagName {
-							allowedTags = append(allowedTags, tagPair)
-							break
+					for _, wTag := range exposedMetric.WhitelistedTags {
+						if strings.Contains(wTag, ":") {
+							if tagPair == wTag {
+								allowedTags = append(allowedTags, tagPair)
+								break
+							}
+						} else {
+							if tag == wTag {
+								allowedTags = append(allowedTags, tagPair)
+								break
+							}
 						}
 					}
 				}

--- a/pkg/metrics/datadog/processing/postprocessing_test.go
+++ b/pkg/metrics/datadog/processing/postprocessing_test.go
@@ -1,0 +1,229 @@
+package processing
+
+import (
+	"testing"
+
+	"github.com/deviceplane/deviceplane/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+var project = models.Project{
+	ID:   "project-id",
+	Name: "project-name",
+}
+var device = models.Device{
+	ID:   "device-id",
+	Name: "device-name",
+	Labels: map[string]string{
+		"company":  "nasa",
+		"location": "ohio",
+	},
+}
+
+func TestFilteringMetrics(t *testing.T) {
+	metrics := []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "Test_Metric",
+			Tags:   []string{"TEST:TRUE"},
+		},
+	}
+	exposedMetrics := []models.ExposedMetric{}
+
+	filteredMetrics := ProcessDeviceMetrics(metrics, exposedMetrics, &project, &device)
+	assert.Len(t, filteredMetrics, 0)
+}
+
+func TestAllowingMetrics(t *testing.T) {
+	metrics := []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "Test_Metric",
+			Tags:   []string{"TEST:TRUE"},
+		},
+		models.DatadogMetric{
+			Metric: "Test_Metric_Two",
+			Tags:   []string{"TEST:TRUE"},
+		},
+	}
+	exposedMetrics := []models.ExposedMetric{
+		models.ExposedMetric{
+			Name: "Test_Metric",
+		},
+	}
+
+	filteredMetrics := ProcessDeviceMetrics(metrics, exposedMetrics, &project, &device)
+	assert.Equal(t, []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric",
+			Tags:   []string{"TEST:TRUE", "deviceplane.project:project-name"},
+		},
+	}, filteredMetrics)
+}
+
+func TestAllowingAllMetrics(t *testing.T) {
+	metrics := []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "Test_Metric",
+			Tags:   []string{"TEST:TRUE"},
+		},
+		models.DatadogMetric{
+			Metric: "Test_Metric_Two",
+			Tags:   []string{"TEST:TRUE"},
+		},
+	}
+	exposedMetrics := []models.ExposedMetric{
+		models.ExposedMetric{
+			Name: "*",
+		},
+	}
+
+	filteredMetrics := ProcessDeviceMetrics(metrics, exposedMetrics, &project, &device)
+	assert.Equal(t, []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric",
+			Tags:   []string{"TEST:TRUE", "deviceplane.project:project-name"},
+		},
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric_Two",
+			Tags:   []string{"TEST:TRUE", "deviceplane.project:project-name"},
+		},
+	}, filteredMetrics)
+}
+
+func TestMetricLabels(t *testing.T) {
+	metrics := []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "Test_Metric",
+			Tags:   []string{"TEST:TRUE"},
+		},
+	}
+	exposedMetrics := []models.ExposedMetric{
+		models.ExposedMetric{
+			Name:   "Test_Metric",
+			Labels: []string{"company"},
+		},
+	}
+
+	filteredMetrics := ProcessDeviceMetrics(metrics, exposedMetrics, &project, &device)
+	assert.Equal(t, []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric",
+			Tags:   []string{"TEST:TRUE", "deviceplane.labels.company:nasa", "deviceplane.project:project-name"},
+		},
+	}, filteredMetrics)
+}
+
+func TestMetricProperties(t *testing.T) {
+	metrics := []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "Test_Metric",
+			Tags:   []string{"TEST:TRUE"},
+		},
+	}
+	exposedMetrics := []models.ExposedMetric{
+		models.ExposedMetric{
+			Name:       "Test_Metric",
+			Properties: []string{"device"},
+		},
+	}
+
+	filteredMetrics := ProcessDeviceMetrics(metrics, exposedMetrics, &project, &device)
+	assert.Equal(t, []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric",
+			Tags:   []string{"TEST:TRUE", "deviceplane.device:device-name", "deviceplane.project:project-name"},
+		},
+	}, filteredMetrics)
+}
+
+func TestMetricSeparation(t *testing.T) {
+	metrics := []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "Test_Metric",
+			Tags:   []string{"TEST:TRUE"},
+		},
+		models.DatadogMetric{
+			Metric: "Test_Metric_Two",
+			Tags:   []string{"TEST:TRUE"},
+		},
+		models.DatadogMetric{
+			Metric: "Test_Metric_Three",
+			Tags:   []string{"TEST:TRUE"},
+		},
+	}
+	exposedMetrics := []models.ExposedMetric{
+		models.ExposedMetric{
+			Name:   "Test_Metric",
+			Labels: []string{"company"},
+		},
+		models.ExposedMetric{
+			Name: "*",
+		},
+		models.ExposedMetric{
+			Name:   "Test_Metric_Three",
+			Labels: []string{"location"},
+		},
+	}
+
+	filteredMetrics := ProcessDeviceMetrics(metrics, exposedMetrics, &project, &device)
+	assert.Equal(t, []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric",
+			Tags:   []string{"TEST:TRUE", "deviceplane.labels.company:nasa", "deviceplane.project:project-name"},
+		},
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric_Two",
+			Tags:   []string{"TEST:TRUE", "deviceplane.project:project-name"},
+		},
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric_Three",
+			Tags:   []string{"TEST:TRUE", "deviceplane.labels.location:ohio", "deviceplane.project:project-name"},
+		},
+	}, filteredMetrics)
+}
+
+func TestMetricTagWhitelist(t *testing.T) {
+	metrics := []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "Test_Metric",
+			Tags:   []string{"TEST:TRUE"},
+		},
+		models.DatadogMetric{
+			Metric: "Test_Metric_Two",
+			Tags:   []string{"TEST:TRUE"},
+		},
+		models.DatadogMetric{
+			Metric: "Test_Metric_Three",
+			Tags:   []string{"TEST:TRUE"},
+		},
+	}
+	exposedMetrics := []models.ExposedMetric{
+		models.ExposedMetric{
+			Name:            "Test_Metric",
+			WhitelistedTags: []string{"TEST"},
+		},
+		models.ExposedMetric{
+			Name:            "Test_Metric_Two",
+			WhitelistedTags: []string{"WEST"},
+		},
+		models.ExposedMetric{
+			Name:            "Test_Metric_Three",
+			WhitelistedTags: []string{},
+		},
+	}
+
+	filteredMetrics := ProcessDeviceMetrics(metrics, exposedMetrics, &project, &device)
+	assert.Equal(t, []models.DatadogMetric{
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric",
+			Tags:   []string{"TEST:TRUE", "deviceplane.project:project-name"},
+		},
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric_Two",
+			Tags:   []string{"deviceplane.project:project-name"},
+		},
+		models.DatadogMetric{
+			Metric: "deviceplane.device.Test_Metric_Three",
+			Tags:   []string{"TEST:TRUE", "deviceplane.project:project-name"},
+		},
+	}, filteredMetrics)
+}

--- a/pkg/models/projectconfigs.go
+++ b/pkg/models/projectconfigs.go
@@ -27,8 +27,13 @@ type DeviceMetricsConfig struct {
 }
 
 type ExposedMetric struct {
-	Name            string   `json:"name" yaml:"name"`
-	Labels          []string `json:"labels" yaml:"labels"`
-	Properties      []string `json:"properties" yaml:"properties"`
-	WhitelistedTags []string `json:"whitelistedTags" yaml:"whitelistedTags"`
+	Name            string           `json:"name" yaml:"name"`
+	Labels          []string         `json:"labels" yaml:"labels"`
+	Properties      []string         `json:"properties" yaml:"properties"`
+	WhitelistedTags []WhitelistedTag `json:"whitelistedTags" yaml:"whitelistedTags"`
+}
+
+type WhitelistedTag struct {
+	Key    string
+	Values []string
 }

--- a/pkg/models/projectconfigs.go
+++ b/pkg/models/projectconfigs.go
@@ -27,7 +27,8 @@ type DeviceMetricsConfig struct {
 }
 
 type ExposedMetric struct {
-	Name       string   `json:"name" yaml:"name"`
-	Labels     []string `json:"labels" yaml:"labels"`
-	Properties []string `json:"properties" yaml:"properties"`
+	Name            string   `json:"name" yaml:"name"`
+	Labels          []string `json:"labels" yaml:"labels"`
+	Properties      []string `json:"properties" yaml:"properties"`
+	WhitelistedTags []string `json:"whitelistedTags" yaml:"whitelistedTags"`
 }

--- a/pkg/models/projectconfigs.go
+++ b/pkg/models/projectconfigs.go
@@ -34,6 +34,6 @@ type ExposedMetric struct {
 }
 
 type WhitelistedTag struct {
-	Key    string
-	Values []string
+	Key    string   `json:"key" yaml:"key"`
+	Values []string `json:"values" yaml:"values"`
 }


### PR DESCRIPTION
This is a backwards-compatible change that allows whitelisting pass-through metric tags on device and service metrics. It works with project metrics too, though it's not needed.

In the context of `deviceplane.device.filesystem_avail_bytes`, which adds "device" tags, to whitelist a tag, simply whitelist the tag name, e.g. "device". If you'd like additional control (e.g. `deviceplane.device.filesystem_avail_bytes` can tag both `device:/dev/xvda1`and `device:tmpfs` for the same deviceplane device), you can whitelist using the value as well, with "device:tmpfs".

Note that this change is backwards-compatible: exposed metrics with an empty tag whitelist will simply forward all tags. Could be unintuitive, we can migrate this in the future.

An example frontend request using this could look like:

`curl 'http://0.0.0.0:3000/api/projects/yeet/configs/device-metrics-config' -X PUT --data '{"exposedMetrics":[{"name":"filesystem_avail_bytes","labels":[],"properties":["device"],"whitelistedTags":[{"key": "device", "values": ["tmpfs"]}]}]}'`

Which will allow through `device:tmpfs`-tagged `deviceplane.device.filesystem_avail_bytes`:
<img width="717" alt="image" src="https://user-images.githubusercontent.com/8443502/74586157-5b08e180-5017-11ea-9b45-9359bf641527.png">
