### PR TITLE
Support deployment of containers which require a tty

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,7 @@ setup_verify_arch() {
 # --- verify existence of network downloader executable ---
 verify_downloader() {
     # Return failure if it doesn't exist or is no executable
-    [ -x "$(which $1)" ] || return 1
+    [ -x "$(which $1 2>/dev/null)" ] || return 1
 
     # Set verified executable as our downloader program and return success
     DOWNLOADER=$1

--- a/pkg/engine/docker/convert.go
+++ b/pkg/engine/docker/convert.go
@@ -22,6 +22,7 @@ func convert(s models.Service) (*container.Config, *container.HostConfig, error)
 			Cmd:          strslice.StrSlice(s.Command),
 			Domainname:   s.DomainName,
 			Entrypoint:   strslice.StrSlice(s.Entrypoint),
+			Tty:          s.Tty,
 			Env:          s.Environment,
 			ExposedPorts: exposedPorts,
 			Hostname:     s.Hostname,

--- a/pkg/models/service.go
+++ b/pkg/models/service.go
@@ -37,6 +37,7 @@ type Service struct {
 	SecurityOpt    []string                  `yaml:"security_opt,omitempty"`
 	ShmSize        yamltypes.MemStringorInt  `yaml:"shm_size,omitempty"`
 	StopSignal     string                    `yaml:"stop_signal,omitempty"`
+	Tty            bool                      `yaml:"tty,omitempty"`
 	User           string                    `yaml:"user,omitempty"`
 	Uts            string                    `yaml:"uts,omitempty"`
 	Volumes        *yamltypes.Volumes        `yaml:"volumes,omitempty"`

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -77,6 +77,7 @@ func applyHash(s models.Service, name string, hash func(string) string) string {
 	parts = append(parts, s.SecurityOpt...)
 	parts = append(parts, fmt.Sprint(s.ShmSize))
 	parts = append(parts, s.StopSignal)
+	parts = append(parts, fmt.Sprint(s.Tty))
 	parts = append(parts, s.User)
 	parts = append(parts, s.Uts)
 	parts = append(parts, s.Volumes.HashString())

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -48,6 +48,7 @@ func fullService() models.Service {
 		SecurityOpt:    []string{"x", "y", "z"},
 		ShmSize:        yamltypes.MemStringorInt(1),
 		StopSignal:     "x",
+		Tty:            true,
 		User:           "x",
 		Uts:            "x",
 		Volumes: &yamltypes.Volumes{

--- a/pkg/spec/validate.go
+++ b/pkg/spec/validate.go
@@ -43,6 +43,7 @@ var (
 		"security_opt":     []func(interface{}) error{validation.ValidateStringArray},
 		"shm_size":         []func(interface{}) error{validation.ValidateStringOrInteger},
 		"stop_signal":      []func(interface{}) error{validation.ValidateString},
+		"tty":              []func(interface{}) error{validation.ValidateBoolean},
 		"user":             []func(interface{}) error{validation.ValidateString},
 		"uts":              []func(interface{}) error{validation.ValidateString},
 		"volumes":          []func(interface{}) error{validation.ValidateStringArray},


### PR DESCRIPTION
This series adds support for containers which require a tty, and a simple cosmetic fix to the install.sh when curl is not on the end device.