### PR TITLE
Let mysql ignore "lost+found" directories, making it more compatible with some volume mounts

### DIFF
--- a/dockerfiles/controller-with-db/entry.sh
+++ b/dockerfiles/controller-with-db/entry.sh
@@ -5,6 +5,6 @@ MYSQL_USER=deviceplane \
   MYSQL_PASSWORD=deviceplane \
   MYSQL_RANDOM_ROOT_PASSWORD=yes \
   MYSQL_DATABASE=deviceplane \
-  docker-entrypoint.sh mysqld --sql-mode="" &
+  docker-entrypoint.sh mysqld --sql-mode="" --ignore-db-dir="lost+found" &
 
 exec controller $@


### PR DESCRIPTION
ignore the lost+found directory, to allow more easy mounting of the mysql datadir (with ext4 volumes for example)

This lets things play a bit more nicely with some storage systems (such as Kubernetes with a storage backend that provisions filesystem based disks, like for example with AWS EKS or our product, KubeSail.com).

We're building a template for DevicePlane over at https://kubesail.com/template/erulabs/deviceplane

Thanks!